### PR TITLE
Bugfixek és gyorsítás

### DIFF
--- a/src/main/java/azahriah/nemhibas/jdktest/Main.java
+++ b/src/main/java/azahriah/nemhibas/jdktest/Main.java
@@ -35,16 +35,18 @@ public class Main {
         executor.shutdown();
     }
 
-    public static String makeReadable(byte[] buffer){
+    public static String makeReadable(byte[] buffer) {
         StringBuilder plus = new StringBuilder();
         StringBuilder s = new StringBuilder();
-        for (byte a : buffer){
+        for (byte a : buffer) {
             if (a < 5) {
                 plus = new StringBuilder();
-            }else {
+            } else {
                 if (plus.length() < 5) {
                     plus.append((char) a);
-                    if (plus.length() == 5) s.append(plus);
+                    if (plus.length() == 5) {
+                        s.append(plus);
+                    }
                 } else {
                     s.append((char) a);
                 }
@@ -80,13 +82,15 @@ public class Main {
                                 boolean runOld;
                                 int offset;
                                 int endIdx;
-                                if ((offset = bufferString.indexOf("{\"access")) > -1){
+                                if ((offset = bufferString.indexOf("{\"access")) > -1) {
                                     runOld = true;
                                     endIdx = bufferString.substring(offset).indexOf("}");
-                                }else if ((offset = bufferString.indexOf("{\"username\"")) > -1 && !bufferString.contains(":{\"username\"")){
+                                } else if ((offset = bufferString.indexOf("{\"username\"")) > -1 && !bufferString.contains(":{\"username\"")) {
                                     runOld = false;
                                     endIdx = bufferString.substring(offset).indexOf(",\"s");
-                                } else continue;
+                                } else {
+                                    continue;
+                                }
 
                                 if (endIdx > 0) {
                                     bufferString = makeReadable(buffer.asSlice(offset, endIdx).toByteArray());
@@ -96,9 +100,11 @@ public class Main {
                                 buffer = segmentAllocator.allocateArray(CLinker.C_CHAR, CHUNK_SIZE);
                                 if (Kernel32.ReadProcessMemory(handle, readPointer.addOffset(offset), buffer, CHUNK_SIZE, MemoryAddress.NULL) != 0) {
                                     bufferString = makeReadable(buffer.toByteArray());
-                                    endIdx = runOld ? bufferString.indexOf("}") :  bufferString.indexOf(",\"s");
+                                    endIdx = runOld ? bufferString.indexOf("}") : bufferString.indexOf(",\"s");
 
-                                    if (endIdx == -1) continue;
+                                    if (endIdx == -1) {
+                                        continue;
+                                    }
 
                                     return bufferString.substring(0, endIdx) + (runOld ? "}}" : "}");
                                 }

--- a/src/main/java/azahriah/nemhibas/jdktest/Main.java
+++ b/src/main/java/azahriah/nemhibas/jdktest/Main.java
@@ -5,8 +5,7 @@ import azahriah.nemhibas.jdktest.natives.windows.kernel32._MEMORY_BASIC_INFORMAT
 import jdk.incubator.foreign.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -22,7 +21,7 @@ public class Main {
             .min(Comparator.comparingDouble(proc -> proc.info().startInstant().get().getEpochSecond()));
 
         if (process.isEmpty()) {
-            System.out.println("[!] The launcher has not started.");
+            System.out.println("[!] The launcher is not running.");
             return;
         }
 
@@ -34,6 +33,24 @@ public class Main {
             }
         });
         executor.shutdown();
+    }
+
+    public static String makeReadable(byte[] buffer){
+        StringBuilder plus = new StringBuilder();
+        StringBuilder s = new StringBuilder();
+        for (byte a : buffer){
+            if (a < 5) {
+                plus = new StringBuilder();
+            }else {
+                if (plus.length() < 5) {
+                    plus.append((char) a);
+                    if (plus.length() == 5) s.append(plus);
+                } else {
+                    s.append((char) a);
+                }
+            }
+        }
+        return s.toString();
     }
 
     public static String tryFindAccessToken(long pid) {
@@ -60,31 +77,30 @@ public class Main {
                             if (Kernel32.ReadProcessMemory(handle, readPointer, buffer, CHUNK_SIZE, MemoryAddress.NULL) != 0) {
                                 String bufferString = new String(buffer.toByteArray(), StandardCharsets.US_ASCII);
 
-                                int method = 0;
-                                int offset = 0;
-                                if (bufferString.contains("{\"access")){
-                                    method = 1;
-                                    offset = bufferString.indexOf("{\"access");
-                                }else if (bufferString.contains("{\"username\"") && !bufferString.contains(":{\"username\"")){
-                                    method = 2;
-                                    offset = bufferString.indexOf("{\"username");
+                                boolean runOld;
+                                int offset;
+                                int endIdx;
+                                if ((offset = bufferString.indexOf("{\"access")) > -1){
+                                    runOld = true;
+                                    endIdx = bufferString.substring(offset).indexOf("}");
+                                }else if ((offset = bufferString.indexOf("{\"username\"")) > -1 && !bufferString.contains(":{\"username\"")){
+                                    runOld = false;
+                                    endIdx = bufferString.substring(offset).indexOf(",\"s");
                                 } else continue;
 
+                                if (endIdx > 0) {
+                                    bufferString = makeReadable(buffer.asSlice(offset, endIdx).toByteArray());
+                                    return bufferString + (runOld ? "}}" : "}");
+                                }
+
                                 buffer = segmentAllocator.allocateArray(CLinker.C_CHAR, CHUNK_SIZE);
-
                                 if (Kernel32.ReadProcessMemory(handle, readPointer.addOffset(offset), buffer, CHUNK_SIZE, MemoryAddress.NULL) != 0) {
-                                    bufferString = new String(buffer.toByteArray(), StandardCharsets.US_ASCII);
+                                    bufferString = makeReadable(buffer.toByteArray());
+                                    endIdx = runOld ? bufferString.indexOf("}") :  bufferString.indexOf(",\"s");
 
-                                    int endIdx = method == 1 ? bufferString.indexOf("}") : bufferString.indexOf(",\"s")-2;
-                                    if (endIdx <= -1) continue;
-                                    StringBuilder result = new StringBuilder(bufferString.substring(0, endIdx+2));
+                                    if (endIdx == -1) continue;
 
-                                    if (method == 2 && result.indexOf("\0d") > 0){
-                                        result = result.delete(result.indexOf("uui")+3, result.indexOf("\0d")+1);
-                                        result = result.delete(result.indexOf("0\0")-1, result.lastIndexOf("\0")+1).append("}");
-                                    }
-
-                                    return result.toString();
+                                    return bufferString.substring(0, endIdx) + (runOld ? "}}" : "}");
                                 }
                             }
                         }


### PR DESCRIPTION
A `makeReadable` kiszűri a negatív és a null byteokat, végül szöveggé alakítja az olvasható eredményt.
Illetve a végeredmény json formátumban másolható.

A gyorsítás az hogy kiszedtem a `JSON_BUFFER_SIZE`-t, és emeltem a `CHUNK_SIZE` értékét, mert a 32-es érték túl lassúnak bizonyult. (Teszteléseim során a legjobb érték az 512)